### PR TITLE
chore: release 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog 2.0.0](https://keepachangelog.com/en/2.
 
 ## [Unreleased]
 
+## [1.1.1] - 2026-07-31
+
 ### Added
 
 - Continuous integration on GitHub Actions, covering Elixir 1.16 through 1.20, each on an OTP release that version supports. The project had no working CI after travis-ci.org shut down.
@@ -37,6 +39,7 @@ The format is based on [Keep a Changelog 2.0.0](https://keepachangelog.com/en/2.
 
 - First release. Build a full or partial deck, shuffle it, deal from it, burn cards, and count what is left.
 
-[Unreleased]: https://github.com/svyatov/deck/compare/v1.1.0...HEAD
+[Unreleased]: https://github.com/svyatov/deck/compare/v1.1.1...HEAD
+[1.1.1]: https://github.com/svyatov/deck/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/svyatov/deck/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/svyatov/deck/releases/tag/v1.0.0

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Deck.MixProject do
   def project do
     [
       app: :deck,
-      version: "1.1.0",
+      version: "1.1.1",
       elixir: "~> 1.6",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
Sets the version in `mix.exs` and closes the `Unreleased` section in `CHANGELOG.md`. The `verify` job in the release workflow compares those two against the tag and fails on a mismatch.

The release itself is the point. Two audit findings can only close on a new tag:

- **R-SEC-05.** `v1.1.0` is a lightweight, unsigned tag. `v1.1.1` will be annotated and SSH-signed.
- **R-PUB-03.** The tarball on Hex for 1.1.0 predates the attestation step, and Hex serves no provenance of its own.

Neither is fixable on `v1.1.0`. Re-cutting a published tag is what the new `refs/tags/*` ruleset exists to prevent.

Contents are a PATCH: CI, community files, documentation, and the SPDX license identifier in `mix.exs`. Nothing in the `Deck` module changed.