### PR TITLE
chore: apply the shared Dependabot policy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,18 +1,31 @@
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-
-  # This entry is the only thing moving mix.lock forward, and it is not a
-  # vulnerability watcher. Dependabot lists mix for version updates and not for
-  # security updates, and GitHub's dependency graph parses no Elixir manifest at
-  # all, so nothing on the forge reads mix.lock against an advisory feed. The
-  # osv-scanner workflow is what covers that; without it an advisory against a
-  # locked dependency reaches nobody. That is how earmark 1.4.3 sat here retired
-  # and carrying a CVE from 2026 until somebody ran a scanner by hand.
+  # This entry is the only thing moving mix.lock forward, and it is not a vulnerability
+  # watcher. Dependabot lists mix for version updates and not for security updates, and
+  # GitHub's dependency graph parses no Elixir manifest at all, so nothing on the forge reads
+  # mix.lock against an advisory feed. The osv-scanner workflow is what covers that; without
+  # it an advisory against a locked dependency reaches nobody. That is how earmark 1.4.3 sat
+  # here retired and carrying a CVE from 2026 until somebody ran a scanner by hand.
   - package-ecosystem: "mix"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: weekly
+    open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
+    groups:
+      mix:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
+    groups:
+      github-actions:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -17,7 +17,9 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Enable auto-merge
-        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        if: >-
+          steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-patch'
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,24 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Fetch dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Minor and patch bumps arrive as one grouped pull request per ecosystem, and majors stay
individual. Every entry is weekly, holds a new release for 7 days, and allows 10 open pull
requests.

The 7-day hold covers the window where a compromised release is normally found. It never
delays a security update.

The limit is stated because a repository at its limit stops opening pull requests and
reports nothing.



Rolled out from ticket 04 of the oss-tracker map, step 1.

The workflow turns on GitHub's auto-merge for any Dependabot pull request whose maximum
update type is not a major, so the grouped minor and patch pull request merges itself once
the required checks pass. Majors still wait for a human, and the required check is the
control: a repository with none merges nothing automatically.

Rolled out from ticket 04 of the oss-tracker map, step 4.
